### PR TITLE
Pass $parentDirectoryId when checking path existence

### DIFF
--- a/src/Microsoft/Drive/DirectoryService.php
+++ b/src/Microsoft/Drive/DirectoryService.php
@@ -159,7 +159,7 @@ class DirectoryService
         $parentDirectoryId = null;
         $createDirectoryResponse = null;
         foreach ($pathParts as $path) {
-            $directoryMeta = $this->requestDirectoryMetadata($path);
+            $directoryMeta = $this->requestDirectoryMetadata($path, $parentDirectoryId);
 
             if ($directoryMeta !== null) {
                 $parentDirectoryId = $directoryMeta['id'];


### PR DESCRIPTION
This fixes not being able to save a file to a path that already exists when the path is more than one directory deep.
For example, with the following folder structure:
```
foo
  | bar
    | foobar.txt
```
`$disk->put("/foo/bar/baz.txt", fopen("baz.txt"))` resulted in this method calling `->requestDirectoryMetadata("bar")`. Because "/bar" doesn't exist on the root directory, it would then try to create "/foo/bar" and throw an exception because "/foo/bar" already exists.